### PR TITLE
Add OpenStack service health check

### DIFF
--- a/check_services.py
+++ b/check_services.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Health-check сервисов OpenStack."""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from contextlib import suppress
+from typing import Dict, List
+
+from openstack_utils import (
+    IMAGE_ID,
+    KEY_NAME,
+    SERVER_NAME_PREFIX,
+    StepResult,
+    TEST_FLAVOR_NAME,
+    TEST_VOLUME_SIZE_GB,
+    TEST_VOLUME_TYPE,
+    WAIT_INTERVAL,
+    WAIT_TIMEOUT,
+    connect,
+    ensure_flavor,
+    ensure_network,
+    ensure_security_group,
+    wait_for_deletion,
+)
+
+
+def _format_error(prefix: str, exc: Exception) -> str:
+    return f"{prefix}: {exc}" if prefix else str(exc)
+
+
+def check_keystone(conn, context: Dict[str, object]) -> StepResult:
+    step_name = "check_keystone"
+    start = time.monotonic()
+    status = "success"
+    message = "Токен Keystone валиден"
+
+    try:
+        conn.authorize()
+    except Exception as exc:  # pylint: disable=broad-except
+        status = "failed"
+        message = _format_error("Не удалось авторизоваться", exc)
+
+    duration = time.monotonic() - start
+    return StepResult(step=step_name, status=status, duration=duration, message=message)
+
+
+def create_test_volume(conn, context: Dict[str, object]) -> StepResult:
+    step_name = "create_test_volume"
+    start = time.monotonic()
+    status = "success"
+    message = "Том создан"
+
+    try:
+        volume = conn.block_storage.create_volume(
+            name=f"{SERVER_NAME_PREFIX}-hc-volume",
+            size=TEST_VOLUME_SIZE_GB,
+            volume_type=TEST_VOLUME_TYPE,
+        )
+        volume = conn.block_storage.wait_for_status(
+            volume,
+            status="available",
+            failures=["error"],
+            wait=WAIT_TIMEOUT,
+            interval=WAIT_INTERVAL,
+        )
+        context["volume"] = volume
+        message = f"Том {volume.id} в состоянии available"
+    except Exception as exc:  # pylint: disable=broad-except
+        status = "failed"
+        message = _format_error("Ошибка создания тестового тома", exc)
+
+    duration = time.monotonic() - start
+    return StepResult(step=step_name, status=status, duration=duration, message=message)
+
+
+def create_test_server(conn, context: Dict[str, object]) -> StepResult:
+    step_name = "create_test_server"
+    start = time.monotonic()
+    status = "success"
+    message = "Сервер создан"
+
+    server = None
+    try:
+        flavor = ensure_flavor(conn, TEST_FLAVOR_NAME)
+        network = ensure_network(conn)
+        security_group = ensure_security_group(conn)
+
+        server = conn.compute.create_server(
+            name=f"{SERVER_NAME_PREFIX}-hc-server",
+            image_id=IMAGE_ID,
+            flavor_id=flavor.id,
+            networks=[{"uuid": network.id}],
+            key_name=KEY_NAME,
+            security_groups=[{"name": security_group.name}],
+        )
+        server = conn.compute.wait_for_server(
+            server,
+            status="ACTIVE",
+            failures=["ERROR"],
+            wait=WAIT_TIMEOUT,
+            interval=WAIT_INTERVAL,
+        )
+        context["server"] = server
+        message = f"Сервер {server.id} в состоянии ACTIVE"
+    except Exception as exc:  # pylint: disable=broad-except
+        status = "failed"
+        message = _format_error("Ошибка создания тестового сервера", exc)
+        if server is not None:
+            with suppress(Exception):
+                conn.compute.delete_server(server, ignore_missing=True)
+    duration = time.monotonic() - start
+    return StepResult(step=step_name, status=status, duration=duration, message=message)
+
+
+def attach_volume(conn, context: Dict[str, object]) -> StepResult:
+    step_name = "attach_volume"
+    start = time.monotonic()
+    status = "success"
+    message = "Том подключён"
+
+    server = context.get("server")
+    volume = context.get("volume")
+    if not server or not volume:
+        duration = time.monotonic() - start
+        return StepResult(
+            step=step_name,
+            status="failed",
+            duration=duration,
+            message="Нет ресурсов для подключения тома",
+        )
+
+    try:
+        conn.compute.create_volume_attachment(server, volumeId=volume.id)
+        volume = conn.block_storage.wait_for_status(
+            volume,
+            status="in-use",
+            failures=["error"],
+            wait=WAIT_TIMEOUT,
+            interval=WAIT_INTERVAL,
+        )
+        context["volume"] = volume
+        context["volume_attached"] = True
+        message = f"Том {volume.id} подключён к серверу {server.id}"
+    except Exception as exc:  # pylint: disable=broad-except
+        status = "failed"
+        message = _format_error("Ошибка подключения тома", exc)
+
+    duration = time.monotonic() - start
+    return StepResult(step=step_name, status=status, duration=duration, message=message)
+
+
+def live_migrate(conn, context: Dict[str, object]) -> StepResult:
+    step_name = "live_migrate"
+    start = time.monotonic()
+    status = "success"
+    message = "Live-migrate завершился"
+
+    server = context.get("server")
+    if not server:
+        duration = time.monotonic() - start
+        return StepResult(
+            step=step_name,
+            status="failed",
+            duration=duration,
+            message="Сервер не найден для live-migrate",
+        )
+
+    try:
+        conn.compute.live_migrate_server(server)
+        server = conn.compute.wait_for_server(
+            server,
+            status="ACTIVE",
+            failures=["ERROR"],
+            wait=WAIT_TIMEOUT,
+            interval=WAIT_INTERVAL,
+        )
+        context["server"] = server
+        message = f"Сервер {server.id} успешно live-migrate"
+    except Exception as exc:  # pylint: disable=broad-except
+        status = "failed"
+        message = _format_error("Live-migrate завершился ошибкой", exc)
+
+    duration = time.monotonic() - start
+    return StepResult(step=step_name, status=status, duration=duration, message=message)
+
+
+def cleanup(conn, context: Dict[str, object]) -> None:
+    server = context.get("server")
+    volume = context.get("volume")
+    should_detach = context.get("volume_attached")
+
+    try:
+        if server and volume and should_detach:
+            with suppress(Exception):
+                conn.compute.detach_volume(server, volume)
+                fresh_volume = conn.block_storage.get_volume(volume.id)
+                if fresh_volume is not None:
+                    conn.block_storage.wait_for_status(
+                        fresh_volume,
+                        status="available",
+                        failures=["error"],
+                        wait=WAIT_TIMEOUT,
+                        interval=WAIT_INTERVAL,
+                    )
+        if server:
+            with suppress(Exception):
+                conn.compute.delete_server(server, ignore_missing=True)
+                wait_for_deletion(
+                    conn.compute.get_server,
+                    server.id,
+                    timeout=WAIT_TIMEOUT,
+                    interval=WAIT_INTERVAL,
+                )
+        if volume:
+            with suppress(Exception):
+                conn.block_storage.delete_volume(volume, ignore_missing=True)
+                wait_for_deletion(
+                    conn.block_storage.get_volume,
+                    volume.id,
+                    timeout=WAIT_TIMEOUT,
+                    interval=WAIT_INTERVAL,
+                )
+    except Exception as exc:  # pylint: disable=broad-except
+        print(f"Ошибка очистки: {exc}", file=sys.stderr)
+
+
+def main() -> None:
+    conn = connect()
+    context: Dict[str, object] = {}
+    results: List[StepResult] = []
+
+    try:
+        for step in (
+            check_keystone,
+            create_test_volume,
+            create_test_server,
+            attach_volume,
+            live_migrate,
+        ):
+            result = step(conn, context)
+            results.append(result)
+            if result.status != "success":
+                break
+    finally:
+        cleanup(conn, context)
+
+    summary = [result.to_dict() for result in results]
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/create_vm.py
+++ b/create_vm.py
@@ -10,25 +10,22 @@
 from __future__ import annotations
 
 import argparse
-import os
 import sys
 from contextlib import suppress
 
-import openstack
 from openstack import exceptions as os_exc
 
-# ===== Константы под твою среду =====
-# UUID образа, из которого будет собираться корневой том. Сейчас это Ubuntu 24.04.
-IMAGE_ID = "47f3d709-a13b-41e0-b930-634e726bcfe8"
-# Название сети, в которую будет подключаться создаваемый порт.
-NETWORK_NAME = "public"
-# Имя уже загруженного в OpenStack SSH-ключа.
-KEY_NAME = "ssh_shevchuk"
-# UUID security group, который необходимо применить.
-SECURITY_GROUP_ID = "f32b1e84-b8e3-44c9-845a-bd242c7707b5"
-# Префикс имени сервера, если пользователь явно не задал имя.
-SERVER_NAME_PREFIX = "shevchuk"
+from openstack_utils import (
+    IMAGE_ID,
+    KEY_NAME,
+    NETWORK_NAME,
+    SECURITY_GROUP_ID,
+    SERVER_NAME_PREFIX,
+    connect,
+)
 
+# ===== Константы под твою среду =====
+# Значения констант импортируются из openstack_utils.py
 
 def parse_args() -> argparse.Namespace:
     """Разбор аргументов командной строки."""
@@ -76,20 +73,6 @@ def build_host_fqdn(host: str | None) -> str | None:
     if not host:
         return None
     return host if "." in host else f"{host}.001.gpucloud.ru"
-
-
-def connect() -> openstack.connection.Connection:
-    """Возвращает соединение с OpenStack.
-
-    Все креды берутся из переменных окружения OS_*, которые появляются после
-    выполнения `source openrc_*.sh`. При желании можно указать cloud через
-    переменную OS_CLOUD.
-    """
-
-    return openstack.connect(
-        cloud=os.getenv("OS_CLOUD", "envvars"),
-        compute_api_version="2.74",
-    )
 
 
 def die(msg: str, code: int = 1) -> None:

--- a/openstack_utils.py
+++ b/openstack_utils.py
@@ -1,0 +1,103 @@
+"""Общие утилиты и константы для сценариев OpenStack."""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass, asdict
+from typing import Callable, Dict, Optional
+
+import openstack
+from openstack import exceptions as os_exc
+
+# ===== Константы под конкретную среду =====
+# UUID образа, из которого будут создаваться тестовые ВМ.
+IMAGE_ID = "47f3d709-a13b-41e0-b930-634e726bcfe8"
+# Название сети для подключения тестовых ресурсов.
+NETWORK_NAME = "public"
+# Имя загруженного SSH-ключа.
+KEY_NAME = "ssh_shevchuk"
+# UUID security group.
+SECURITY_GROUP_ID = "f32b1e84-b8e3-44c9-845a-bd242c7707b5"
+# Префикс имени тестовых серверов.
+SERVER_NAME_PREFIX = "shevchuk"
+
+# Дополнительные параметры для health-check скриптов.
+TEST_FLAVOR_NAME = "amd-1-1"
+TEST_VOLUME_TYPE = "SSD"
+TEST_VOLUME_SIZE_GB = 10
+WAIT_TIMEOUT = 600
+WAIT_INTERVAL = 5
+
+
+@dataclass
+class StepResult:
+    """Результат выполнения шага health-check."""
+
+    step: str
+    status: str
+    duration: float
+    message: str = ""
+
+    def to_dict(self) -> Dict[str, object]:
+        payload = asdict(self)
+        payload["duration"] = round(self.duration, 3)
+        return payload
+
+
+def connect() -> openstack.connection.Connection:
+    """Возвращает соединение с OpenStack."""
+
+    return openstack.connect(
+        cloud=os.getenv("OS_CLOUD", "envvars"),
+        compute_api_version="2.74",
+    )
+
+
+def ensure_network(conn: openstack.connection.Connection):
+    """Возвращает объект сети по имени из константы."""
+
+    return conn.network.find_network(NETWORK_NAME, ignore_missing=False)
+
+
+def ensure_security_group(conn: openstack.connection.Connection):
+    """Возвращает security group, выбрасывая исключение при отсутствии."""
+
+    sg = conn.network.get_security_group(SECURITY_GROUP_ID)
+    if not sg:
+        raise os_exc.ResourceNotFound(
+            f"Security group {SECURITY_GROUP_ID} не найден"
+        )
+    return sg
+
+
+def ensure_flavor(
+    conn: openstack.connection.Connection,
+    flavor_name: Optional[str] = None,
+):
+    """Возвращает flavor по имени/ID."""
+
+    name = flavor_name or TEST_FLAVOR_NAME
+    return conn.compute.find_flavor(name, ignore_missing=False)
+
+
+def wait_for_deletion(
+    getter: Callable[..., object],
+    *getter_args,
+    timeout: int = WAIT_TIMEOUT,
+    interval: int = WAIT_INTERVAL,
+    **getter_kwargs,
+) -> None:
+    """Ожидает удаления ресурса."""
+
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            resource = getter(*getter_args, **getter_kwargs)
+        except os_exc.ResourceNotFound:
+            return
+        if not resource:
+            return
+        if time.monotonic() >= deadline:
+            raise TimeoutError("Тайм-аут ожидания удаления ресурса")
+        time.sleep(interval)


### PR DESCRIPTION
## Summary
- add reusable OpenStack utility module with shared constants, connection helper, and wait helpers
- implement `check_services.py` to run sequential Keystone, volume, server, attach, and live-migrate checks with cleanup and JSON summary
- update `create_vm.py` to reuse constants and connection helper from the new utility module

## Testing
- python -m compileall check_services.py openstack_utils.py create_vm.py

------
https://chatgpt.com/codex/tasks/task_b_68e19f72029883329c494970eae006fe