### PR TITLE
Add service health check workflow and shared OpenStack helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,114 @@
+# Скрипты для ручных проверок OpenStack
+
+В репозитории два скрипта:
+
+* `create_vm.py` — быстрая обёртка, создающая тестовую ВМ из заранее заданных
+  параметров.
+* `check_services.py` — сценарий проверки базовых сервисов (Keystone, Cinder,
+  Nova) и, при желании, дополнительных шагов (floating IP, снапшот, консоль).
+
+## Требования
+
+* Python 3.8+
+* Установленный клиент OpenStack для Ubuntu (`python3-openstackclient`). Он
+  подтягивает и сам CLI, и библиотеку [`openstacksdk`](https://docs.openstack.org/openstacksdk/latest/),
+  которую использует скрипт.
+* Настроенные переменные окружения OpenStack (`OS_`), например через
+  `source openrc_*.sh`
+
+## Подготовка
+
+1. Убедись, что значения констант в `openstack_utils.py` соответствуют твоей
+   среде:
+   * `IMAGE_ID` — UUID образа для корневого тома
+   * `NETWORK_NAME` — имя сети, куда подключить ВМ
+   * `KEY_NAME` — имя загруженного в OpenStack SSH-ключа
+   * `SECURITY_GROUP_ID` — UUID security group
+   * `SERVER_NAME_PREFIX` — префикс имени сервера по умолчанию
+2. Установи зависимости. Для Ubuntu 22.04+ достаточно установить официальный
+   пакет клиента:
+
+   ```bash
+   sudo apt install python3-openstackclient
+   ```
+
+   Если хочется управлять окружением через `pip`, можно поставить SDK
+   непосредственно:
+
+   ```bash
+   pip install --user openstacksdk
+   ```
+
+## create_vm.py
+
+### Использование
+
+```bash
+python3 create_vm.py FLAVOR VOLUME_TYPE SIZE_GB [HOST] [--name NAME]
+```
+
+* `FLAVOR` — имя или ID нужного flavor, например `amd-1-1`
+* `VOLUME_TYPE` — тип корневого тома (`SSD`, `NVME`, `HDD`, `SSD-MA` и т.д.)
+* `SIZE_GB` — размер корневого тома в гигабайтах
+* `HOST` *(опционально)* — compute-нода; можно указать короткое имя (`o2n40`),
+  домен добавится автоматически
+* `--name` *(опционально)* — пользовательское имя сервера
+
+Пример:
+
+```bash
+python3 create_vm.py amd-1-1 SSD 20 o2n9 --name shevchuk_auto
+```
+
+### Вывод
+
+При успешном выполнении скрипт печатает итоговую информацию о ресурсе:
+
+```
+OK
+id=<uuid>
+name=<vm-name>
+hypervisor=<fqdn>
+addresses={<network-info>}
+volume_id=<volume-uuid>
+```
+
+В случае ошибки сообщение будет выведено в STDERR, а код возврата будет > 0.
+
+## check_services.py
+
+Сценарий автоматизирует цепочку действий, которые обычно выполняешь вручную
+при проверке сервисов после аварий: запрос токена в Keystone, создание и
+подготовка томов в Cinder, развёртывание и миграцию ВМ в Nova. Скрипт
+автоматически очищает все созданные ресурсы.
+
+### Использование
+
+```
+python3 check_services.py FLAVOR ROOT_VOLUME_TYPE ROOT_SIZE_GB [HOST] [опции]
+```
+
+Основные аргументы совпадают с `create_vm.py`. Дополнительные флаги:
+
+* `--data-volume-type TYPE` и `--data-volume-size SIZE` — контролируют
+  параметры дополнительного тома, который будет подключён к ВМ для проверки
+  Cinder.
+* `--skip-live-migration` — отключает live migration.
+* `--migration-target HOST` — явно задаёт целевой hypervisor для миграции.
+* `--with-floating-ip` — проверяет Neutron: создаёт floating IP и назначает его
+  серверу.
+* `--with-snapshot` — создаёт снапшот дополнительного тома.
+* `--with-console` — запрашивает консольный вывод ВМ (первые 50 строк).
+* `--json` — печатает сводку в JSON.
+
+### Пример запуска
+
+```
+python3 check_services.py amd-1-1 SSD 20 o2n9 --with-floating-ip --with-console
+```
+
+### Вывод
+
+После выполнения скрипт выводит таблицу (или JSON при `--json`) с этапами
+проверки, статусами и временем выполнения. При любой ошибке команда завершается
+с кодом `1`, но перед этим всё созданное будет удалено.

--- a/check_services.py
+++ b/check_services.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""Сценарий проверки базовых сервисов OpenStack (Keystone, Cinder, Nova)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from contextlib import suppress
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from openstack_utils import (
+    IMAGE_ID,
+    KEY_NAME,
+    NETWORK_NAME,
+    SECURITY_GROUP_ID,
+    SERVER_NAME_PREFIX,
+    build_host_fqdn,
+    connect,
+    create_server_from_volume,
+    create_volume,
+    delete_server,
+    delete_volume,
+    detach_volume,
+    ensure_positive_size,
+    resolve_base_resources,
+    wait_for_server,
+    wait_for_volume,
+)
+
+
+@dataclass
+class StepResult:
+    """Итог выполнения отдельного шага."""
+
+    name: str
+    success: bool
+    duration: float
+    message: str = ""
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "success": self.success,
+            "duration": self.duration,
+            "message": self.message,
+            "details": self.details,
+        }
+
+
+@dataclass
+class ResourceState:
+    """Следит за созданными ресурсами, чтобы корректно их удалить."""
+
+    root_volume_id: str | None = None
+    server_id: str | None = None
+    server_name: str | None = None
+    data_volume_id: str | None = None
+    data_volume_attached: bool = False
+    floating_ip_id: str | None = None
+    floating_ip_address: str | None = None
+    snapshot_id: str | None = None
+
+
+StepFunc = Callable[[], Any]
+
+
+def run_step(name: str, func: StepFunc) -> tuple[StepResult, Any]:
+    """Запускает отдельный шаг и возвращает результат вместе с данными."""
+
+    start = time.monotonic()
+    try:
+        data = func()
+    except Exception as exc:  # noqa: BLE001 - фиксируем оригинальную ошибку
+        duration = time.monotonic() - start
+        return (
+            StepResult(name=name, success=False, duration=duration, message=str(exc)),
+            None,
+        )
+    else:
+        duration = time.monotonic() - start
+        message = "OK"
+        if isinstance(data, dict) and data.get("__message"):
+            message = data["__message"]
+        return (
+            StepResult(
+                name=name,
+                success=True,
+                duration=duration,
+                message=message,
+                details=data if isinstance(data, dict) else {},
+            ),
+            data,
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("flavor", help="Имя/ID flavor, напр. amd-1-1")
+    parser.add_argument("root_volume_type", help="Тип корневого тома: SSD | HDD | NVME")
+    parser.add_argument("root_size", type=int, help="Размер корневого тома в ГБ")
+    parser.add_argument(
+        "host",
+        nargs="?",
+        default=None,
+        help="Опционально: o2nX или FQDN compute-ноды",
+    )
+    parser.add_argument("--name", default=None, help="Имя тестовой ВМ")
+    parser.add_argument(
+        "--data-volume-type",
+        default=None,
+        help="Тип дополнительного тома (по умолчанию как корневой)",
+    )
+    parser.add_argument(
+        "--data-volume-size",
+        type=int,
+        default=10,
+        help="Размер дополнительного тома (ГБ)",
+    )
+    parser.add_argument(
+        "--skip-live-migration",
+        action="store_true",
+        help="Не выполнять live migration",
+    )
+    parser.add_argument(
+        "--migration-target",
+        default=None,
+        help="Явно указать compute-ноду для live migration",
+    )
+    parser.add_argument(
+        "--with-floating-ip",
+        action="store_true",
+        help="Создать и привязать floating IP (Neutron)",
+    )
+    parser.add_argument(
+        "--with-snapshot",
+        action="store_true",
+        help="Создать снапшот дополнительного тома",
+    )
+    parser.add_argument(
+        "--with-console",
+        action="store_true",
+        help="Запросить консольный вывод ВМ",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Вывести итоговую сводку в JSON вместо таблицы",
+    )
+    return parser.parse_args()
+
+
+def format_summary(results: list[StepResult], *, json_output: bool) -> str:
+    if json_output:
+        return json.dumps([r.as_dict() for r in results], indent=2, ensure_ascii=False)
+
+    lines = ["\n=== Итоговая сводка ==="]
+    header = f"{'Шаг':30} | {'Статус':8} | {'Время':>8} | Сообщение"
+    lines.append(header)
+    lines.append("-" * len(header))
+    for res in results:
+        status = "OK" if res.success else "FAIL"
+        lines.append(f"{res.name:30} | {status:8} | {res.duration:8.2f} | {res.message}")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    args = parse_args()
+    ensure_positive_size(args.root_size, what="Размер корневого тома")
+    ensure_positive_size(args.data_volume_size, what="Размер доп. тома")
+
+    server_name = args.name or f"{SERVER_NAME_PREFIX}_hc"
+    host_fqdn = build_host_fqdn(args.host)
+    migration_target = build_host_fqdn(args.migration_target)
+
+    conn = connect()
+    state = ResourceState()
+    results: list[StepResult] = []
+
+    try:
+        step_result, data = run_step("keystone", conn.authorize)
+        results.append(step_result)
+        if not step_result.success:
+            raise SystemExit(1)
+
+        def resolve_resources() -> dict[str, Any]:
+            resolved = resolve_base_resources(
+                conn,
+                network_name=NETWORK_NAME,
+                flavor_name=args.flavor,
+                security_group_id=SECURITY_GROUP_ID,
+            )
+            return {
+                "network_id": resolved.network_id,
+                "flavor_id": resolved.flavor_id,
+                "security_group": resolved.security_group_name,
+                "__message": "Ресурсы найдены",
+            }
+
+        step_result, data = run_step("lookup", resolve_resources)
+        results.append(step_result)
+        if not step_result.success:
+            raise SystemExit(1)
+        network_id = data["network_id"]
+        flavor_id = data["flavor_id"]
+        security_group_name = data["security_group"]
+
+        def create_root_volume() -> dict[str, Any]:
+            volume = create_volume(
+                conn,
+                name=f"{server_name}-root",
+                size_gb=args.root_size,
+                volume_type=args.root_volume_type,
+                image_id=IMAGE_ID,
+            )
+            state.root_volume_id = volume.id
+            return {
+                "volume_id": volume.id,
+                "status": volume.status,
+            }
+
+        step_result, data = run_step("root-volume", create_root_volume)
+        results.append(step_result)
+        if not step_result.success:
+            raise SystemExit(1)
+
+        def create_server() -> dict[str, Any]:
+            server = create_server_from_volume(
+                conn,
+                name=server_name,
+                flavor_id=flavor_id,
+                volume_id=state.root_volume_id,
+                network_id=network_id,
+                security_group_name=security_group_name,
+                key_name=KEY_NAME,
+                host_fqdn=host_fqdn,
+            )
+            state.server_id = server.id
+            state.server_name = server.name
+            server = conn.compute.get_server(server.id)
+            return {
+                "server_id": server.id,
+                "status": server.status,
+                "hypervisor": getattr(server, "hypervisor_hostname", None),
+            }
+
+        step_result, data = run_step("server", create_server)
+        results.append(step_result)
+        if not step_result.success:
+            raise SystemExit(1)
+
+        def create_data_volume() -> dict[str, Any]:
+            volume = create_volume(
+                conn,
+                name=f"{server_name}-data",
+                size_gb=args.data_volume_size,
+                volume_type=args.data_volume_type or args.root_volume_type,
+            )
+            state.data_volume_id = volume.id
+            return {"volume_id": volume.id, "status": volume.status}
+
+        step_result, data = run_step("data-volume", create_data_volume)
+        results.append(step_result)
+        if not step_result.success:
+            raise SystemExit(1)
+
+        def attach_volume() -> dict[str, Any]:
+            server = conn.compute.get_server(state.server_id)
+            attachment = conn.compute.create_volume_attachment(
+                server,
+                volumeId=state.data_volume_id,
+            )
+            state.data_volume_attached = True
+            wait_for_volume(
+                conn,
+                conn.block_storage.get_volume(state.data_volume_id),
+                status="in-use",
+            )
+            return {
+                "attachment_id": attachment.id,
+                "device": getattr(attachment, "device", None),
+            }
+
+        step_result, _ = run_step("attach", attach_volume)
+        results.append(step_result)
+        if not step_result.success:
+            raise SystemExit(1)
+
+        if not args.skip_live_migration:
+            def live_migrate() -> dict[str, Any]:
+                server = conn.compute.get_server(state.server_id)
+                initial_host = getattr(server, "OS-EXT-SRV-ATTR:host", None)
+                conn.compute.live_migrate_server(server, host=migration_target)
+                server = wait_for_server(conn, server)
+                new_host = getattr(server, "OS-EXT-SRV-ATTR:host", None)
+                return {
+                    "from": initial_host,
+                    "to": new_host,
+                    "__message": "Миграция выполнена" if initial_host != new_host else "Миграция завершена (хост не изменился)",
+                }
+
+            step_result, _ = run_step("live-migrate", live_migrate)
+            results.append(step_result)
+            if not step_result.success:
+                raise SystemExit(1)
+
+        if args.with_floating_ip:
+            def floating_ip() -> dict[str, Any]:
+                server = conn.compute.get_server(state.server_id)
+                fip = conn.network.create_ip(floating_network_id=network_id)
+                state.floating_ip_id = fip.id
+                state.floating_ip_address = fip.floating_ip_address
+                conn.compute.add_floating_ip_to_server(
+                    server,
+                    fip.floating_ip_address,
+                )
+                server = conn.compute.get_server(server.id)
+                return {
+                    "floating_ip": fip.floating_ip_address,
+                    "addresses": server.addresses,
+                }
+
+            step_result, _ = run_step("floating-ip", floating_ip)
+            results.append(step_result)
+            if not step_result.success:
+                raise SystemExit(1)
+
+        if args.with_snapshot:
+            def snapshot() -> dict[str, Any]:
+                volume = conn.block_storage.get_volume(state.data_volume_id)
+                snapshot = conn.block_storage.create_snapshot(
+                    name=f"{server_name}-snap",
+                    volume_id=volume.id,
+                    force=True,
+                )
+                snapshot = conn.block_storage.wait_for_status(
+                    snapshot,
+                    status="available",
+                    failures=["error"],
+                )
+                state.snapshot_id = snapshot.id
+                return {
+                    "snapshot_id": snapshot.id,
+                    "status": snapshot.status,
+                }
+
+            step_result, _ = run_step("snapshot", snapshot)
+            results.append(step_result)
+            if not step_result.success:
+                raise SystemExit(1)
+
+        if args.with_console:
+            def console() -> dict[str, Any]:
+                output = conn.compute.get_server_console_output(state.server_id, length=50)
+                # Ограничим длину сообщения, чтобы не засорять вывод.
+                truncated = (output[:500] + "...") if len(output) > 500 else output
+                return {
+                    "lines": truncated,
+                    "__message": "Получен вывод консоли",
+                }
+
+            step_result, _ = run_step("console", console)
+            results.append(step_result)
+            if not step_result.success:
+                raise SystemExit(1)
+
+    except SystemExit:
+        # Прерываем сценарий, но всё равно выполняем очистку.
+        pass
+    finally:
+        if state.server_id and state.data_volume_attached and state.data_volume_id:
+            with suppress(Exception):
+                detach_volume(
+                    conn,
+                    server_id=state.server_id,
+                    volume_id=state.data_volume_id,
+                )
+        if state.floating_ip_id and state.floating_ip_address and state.server_id:
+            with suppress(Exception):
+                server = conn.compute.get_server(state.server_id)
+                conn.compute.remove_floating_ip_from_server(
+                    server,
+                    state.floating_ip_address,
+                )
+            with suppress(Exception):
+                conn.network.delete_ip(state.floating_ip_id, ignore_missing=True)
+        if state.snapshot_id:
+            with suppress(Exception):
+                snapshot = conn.block_storage.get_snapshot(state.snapshot_id)
+                if snapshot:
+                    conn.block_storage.delete_snapshot(snapshot, ignore_missing=True)
+                    conn.block_storage.wait_for_delete(snapshot)
+        if state.server_id:
+            with suppress(Exception):
+                delete_server(conn, state.server_id)
+        if state.data_volume_id:
+            with suppress(Exception):
+                delete_volume(conn, state.data_volume_id)
+        if state.root_volume_id:
+            with suppress(Exception):
+                delete_volume(conn, state.root_volume_id)
+
+    print(format_summary(results, json_output=args.json))
+
+    # Если какой-то шаг провалился — вернём ненулевой код возврата.
+    if any(not res.success for res in results):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/create_vm.py
+++ b/create_vm.py
@@ -1,101 +1,125 @@
 #!/usr/bin/env python3
+"""Утилита для создания виртуальной машины в OpenStack."""
+
+from __future__ import annotations
+
 import argparse
-import os
 import sys
-import time
-import openstack
+from contextlib import suppress
+
 from openstack import exceptions as os_exc
 
-# ===== Константы под твою среду =====
-IMAGE_ID = "47f3d709-a13b-41e0-b930-634e726bcfe8"   # Ubuntu-24.04-LTS
-NETWORK_NAME = "public"
-KEY_NAME = "ssh_shevchuk"
-SECURITY_GROUP_ID = "f32b1e84-b8e3-44c9-845a-bd242c7707b5"
-SERVER_NAME_PREFIX = "shevchuk"
-
-# ===== Аргументы =====
-p = argparse.ArgumentParser(
-    description="Создать ВМ: FLAVOR VOLUME_TYPE SIZE_GB [HOST]\n"
-                "Пример: create_vm.py amd-1-1 SSD 30 o2n40"
+from openstack_utils import (
+    IMAGE_ID,
+    KEY_NAME,
+    NETWORK_NAME,
+    SECURITY_GROUP_ID,
+    SERVER_NAME_PREFIX,
+    build_host_fqdn,
+    connect,
+    create_server_from_volume,
+    create_volume,
+    delete_volume,
+    ensure_positive_size,
+    resolve_base_resources,
 )
-p.add_argument("flavor", help="Имя/ID flavor, напр. amd-1-1")
-p.add_argument("volume_type", help="Тип тома Cinder: SSD | NVME | HDD | SSD-MA")
-p.add_argument("size_gb", type=int, help="Размер корневого тома в ГБ")
-p.add_argument("host", nargs="?", default=None,
-               help="Опционально: o2nX или FQDN, напр. o2n40 или o2n40.001.gpucloud.ru")
-p.add_argument("--name", default=None, help="Имя ВМ (опционально)")
-args = p.parse_args()
 
-name = args.name or f"{SERVER_NAME_PREFIX}_auto"
-host = args.host
-if host and "." not in host:
-    host = f"{host}.001.gpucloud.ru"
 
-# ===== Подключение =====
-# Берёт креды из OS_* после `source openrc_*.sh`
-conn = openstack.connect(cloud=os.getenv("OS_CLOUD", "envvars"),
-                         compute_api_version="2.74")
+def parse_args() -> argparse.Namespace:
+    """Разбор аргументов командной строки."""
 
-def die(msg, code=1):
+    parser = argparse.ArgumentParser(
+        description=(
+            "Создать ВМ: FLAVOR VOLUME_TYPE SIZE_GB [HOST]\n"
+            "Пример: create_vm.py amd-1-1 SSD 30 o2n40"
+        )
+    )
+    parser.add_argument("flavor", help="Имя/ID flavor, напр. amd-1-1")
+    parser.add_argument(
+        "volume_type",
+        help="Тип тома Cinder: SSD | NVME | HDD | SSD-MA",
+    )
+    parser.add_argument(
+        "size_gb",
+        type=int,
+        help="Размер корневого тома в ГБ",
+    )
+    parser.add_argument(
+        "host",
+        nargs="?",
+        default=None,
+        help="Опционально: o2nX или FQDN, напр. o2n40 или o2n40.001.gpucloud.ru",
+    )
+    parser.add_argument("--name", default=None, help="Имя ВМ (опционально)")
+    return parser.parse_args()
+
+
+def die(msg: str, code: int = 1) -> None:
+    """Печатает сообщение об ошибке и завершает процесс."""
+
     print(f"Error: {msg}", file=sys.stderr)
     sys.exit(code)
 
-try:
-    # сеть, flavor, SG
-    net = conn.network.find_network(NETWORK_NAME, ignore_missing=False)
-    flv = conn.compute.find_flavor(args.flavor, ignore_missing=False)
-    sg = conn.network.get_security_group(SECURITY_GROUP_ID)
-    if not sg:
-        die(f"Security group {SECURITY_GROUP_ID} не найден")
 
-    # корневой том нужного типа из образа
-    vol = conn.block_storage.create_volume(
-        name=f"{name}-root",
-        size=args.size_gb,
-        image_id=IMAGE_ID,
-        volume_type=args.volume_type,
-    )
-    vol = conn.block_storage.wait_for_status(vol, status="available", failures=["error"])
-    host_fqdn = None
-    if args.host:
-        host_fqdn = args.host if "." in args.host else f"{args.host}.001.gpucloud.ru"
+def main() -> None:
+    args = parse_args()
+    ensure_positive_size(args.size_gb)
 
-    # создание сервера: сеть по UUID, SG по имени (Nova применит к автопорту)
-    server_kwargs = dict(
-        name=name,
-        flavor_id=flv.id,
-        block_device_mapping_v2=[{
-            "boot_index": 0,
-            "uuid": vol.id,
-            "source_type": "volume",
-            "destination_type": "volume",
-            "delete_on_termination": True,
-        }],
-        networks=[{"uuid": net.id}],
-        security_groups=[{"name": sg.name}],
-        key_name=KEY_NAME,
-    )
-    if host_fqdn:
-        server_kwargs["availability_zone"] = f"nova:{host_fqdn}"
+    name = args.name or f"{SERVER_NAME_PREFIX}_auto"
+    host_fqdn = build_host_fqdn(args.host)
 
-    srv = conn.compute.create_server(**server_kwargs)
-    srv = conn.compute.wait_for_server(srv, status="ACTIVE", failures=["ERROR"])
+    conn = connect()
 
-    # вывод
-    srv = conn.compute.get_server(srv.id)
-    hyper = getattr(srv, "hypervisor_hostname", None)
+    try:
+        resources = resolve_base_resources(
+            conn,
+            network_name=NETWORK_NAME,
+            flavor_name=args.flavor,
+            security_group_id=SECURITY_GROUP_ID,
+        )
+
+        volume = create_volume(
+            conn,
+            name=f"{name}-root",
+            size_gb=args.size_gb,
+            volume_type=args.volume_type,
+            image_id=IMAGE_ID,
+        )
+
+        server = None
+        try:
+            server = create_server_from_volume(
+                conn,
+                name=name,
+                flavor_id=resources.flavor_id,
+                volume_id=volume.id,
+                network_id=resources.network_id,
+                security_group_name=resources.security_group_name,
+                key_name=KEY_NAME,
+                host_fqdn=host_fqdn,
+            )
+        except Exception:
+            with suppress(Exception):
+                delete_volume(conn, volume.id)
+            raise
+
+        server = conn.compute.get_server(server.id)
+        hyper = getattr(server, "hypervisor_hostname", None)
+
+        print("OK")
+        print(f"id={server.id}")
+        print(f"name={server.name}")
+        print(f"hypervisor=" + (hyper or "(unknown)"))
+        print(f"addresses={server.addresses or {}}")
+        print(f"volume_id={volume.id}")
+
+    except os_exc.ResourceNotFound as exc:
+        die(f"Ресурс не найден: {exc}")
+    except os_exc.HttpException as exc:
+        die(f"HTTP error: {exc}")
+    except Exception as exc:
+        die(str(exc))
 
 
-    print("OK")
-    print(f"id={srv.id}")
-    print(f"name={srv.name}")
-    print(f"hypervisor=" + (hyper or "(unknown)"))
-    print(f"addresses={srv.addresses or {}}")
-    print(f"volume_id={vol.id}")
-
-except os_exc.ResourceNotFound as e:
-    die(f"Ресурс не найден: {e}")
-except os_exc.HttpException as e:
-    die(f"HTTP error: {e}")
-except Exception as e:
-    die(str(e))
+if __name__ == "__main__":
+    main()

--- a/openstack_utils.py
+++ b/openstack_utils.py
@@ -1,0 +1,276 @@
+"""Общие утилиты для скриптов, работающих с OpenStack."""
+
+from __future__ import annotations
+
+import os
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Sequence
+
+import openstack
+from openstack import connection, exceptions as os_exc
+
+# ===== Константы под твою среду =====
+# UUID образа, из которого будет собираться корневой том. Сейчас это Ubuntu 24.04.
+IMAGE_ID = "47f3d709-a13b-41e0-b930-634e726bcfe8"
+# Название сети, в которую будет подключаться создаваемый порт.
+NETWORK_NAME = "public"
+# Имя уже загруженного в OpenStack SSH-ключа.
+KEY_NAME = "ssh_shevchuk"
+# UUID security group, который необходимо применить.
+SECURITY_GROUP_ID = "f32b1e84-b8e3-44c9-845a-bd242c7707b5"
+# Префикс имени сервера, если пользователь явно не задал имя.
+SERVER_NAME_PREFIX = "shevchuk"
+# Домен для автоматического дополнения коротких имен compute-нод.
+DEFAULT_HOST_DOMAIN = "001.gpucloud.ru"
+# Версия API Nova, которая поддерживает live migration и расширенные поля.
+COMPUTE_API_VERSION = "2.74"
+
+# Тайм-ауты ожиданий (секунды)
+DEFAULT_VOLUME_WAIT_TIMEOUT = 600
+DEFAULT_SERVER_WAIT_TIMEOUT = 900
+DEFAULT_WAIT_INTERVAL = 5
+
+
+@dataclass(frozen=True)
+class ResolvedResources:
+    """Набор заранее найденных ресурсов OpenStack."""
+
+    network_id: str
+    flavor_id: str
+    security_group_name: str
+
+
+def connect() -> connection.Connection:
+    """Возвращает соединение с OpenStack."""
+
+    return openstack.connect(
+        cloud=os.getenv("OS_CLOUD", "envvars"),
+        compute_api_version=COMPUTE_API_VERSION,
+    )
+
+
+def ensure_positive_size(size_gb: int, *, what: str = "Размер тома") -> None:
+    """Проверяет, что указанный размер положительный."""
+
+    if size_gb <= 0:
+        raise ValueError(f"{what} должен быть больше нуля")
+
+
+def build_host_fqdn(host: str | None, *, domain: str = DEFAULT_HOST_DOMAIN) -> str | None:
+    """Дополняет короткое имя compute-ноды до FQDN."""
+
+    if not host:
+        return None
+    return host if "." in host else f"{host}.{domain}"
+
+
+def resolve_base_resources(
+    conn: connection.Connection,
+    *,
+    network_name: str,
+    flavor_name: str,
+    security_group_id: str,
+) -> ResolvedResources:
+    """Находит базовые ресурсы, требуемые для создания сервера."""
+
+    network = conn.network.find_network(network_name, ignore_missing=False)
+    flavor = conn.compute.find_flavor(flavor_name, ignore_missing=False)
+    security_group = conn.network.get_security_group(security_group_id)
+    if not security_group:
+        raise os_exc.ResourceNotFound(f"Security group {security_group_id} не найден")
+    return ResolvedResources(
+        network_id=network.id,
+        flavor_id=flavor.id,
+        security_group_name=security_group.name,
+    )
+
+
+def wait_for_volume(
+    conn: connection.Connection,
+    volume,
+    *,
+    status: str = "available",
+    failures: Sequence[str] | None = None,
+    interval: int = DEFAULT_WAIT_INTERVAL,
+    wait: int = DEFAULT_VOLUME_WAIT_TIMEOUT,
+):
+    """Дожидается нужного статуса тома."""
+
+    failures = tuple(failures or ("error", "error_deleting"))
+    return conn.block_storage.wait_for_status(
+        volume,
+        status=status,
+        failures=list(failures),
+        interval=interval,
+        wait=wait,
+    )
+
+
+def create_volume(
+    conn: connection.Connection,
+    *,
+    name: str,
+    size_gb: int,
+    volume_type: str,
+    image_id: str | None = None,
+    wait: bool = True,
+):
+    """Создаёт том и при необходимости дожидается готовности."""
+
+    ensure_positive_size(size_gb)
+    volume = conn.block_storage.create_volume(
+        name=name,
+        size=size_gb,
+        volume_type=volume_type,
+        image_id=image_id,
+    )
+    if wait:
+        volume = wait_for_volume(conn, volume)
+    return volume
+
+
+def delete_volume(
+    conn: connection.Connection,
+    volume_id: str | None,
+    *,
+    wait: bool = True,
+    interval: int = DEFAULT_WAIT_INTERVAL,
+    timeout: int = DEFAULT_VOLUME_WAIT_TIMEOUT,
+) -> None:
+    """Удаляет том и, при необходимости, ждёт завершения операции."""
+
+    if not volume_id:
+        return
+    with suppress(os_exc.ResourceNotFound):
+        volume = conn.block_storage.get_volume(volume_id)
+        if not volume:
+            return
+        conn.block_storage.delete_volume(volume, ignore_missing=True)
+        if wait:
+            conn.block_storage.wait_for_delete(volume, interval=interval, wait=timeout)
+
+
+def wait_for_server(
+    conn: connection.Connection,
+    server,
+    *,
+    status: str = "ACTIVE",
+    failures: Sequence[str] | None = None,
+    interval: int = DEFAULT_WAIT_INTERVAL,
+    wait: int = DEFAULT_SERVER_WAIT_TIMEOUT,
+):
+    """Дожидается нужного статуса сервера."""
+
+    failures = tuple(failures or ("ERROR", "VERIFY_RESIZE"))
+    return conn.compute.wait_for_server(
+        server,
+        status=status,
+        failures=list(failures),
+        interval=interval,
+        wait=wait,
+    )
+
+
+def create_server_from_volume(
+    conn: connection.Connection,
+    *,
+    name: str,
+    flavor_id: str,
+    volume_id: str,
+    network_id: str,
+    security_group_name: str,
+    key_name: str,
+    host_fqdn: str | None = None,
+    wait: bool = True,
+):
+    """Создаёт сервер, бутящийся с указанного тома."""
+
+    server_kwargs = dict(
+        name=name,
+        flavor_id=flavor_id,
+        block_device_mapping_v2=[
+            {
+                "boot_index": 0,
+                "uuid": volume_id,
+                "source_type": "volume",
+                "destination_type": "volume",
+                "delete_on_termination": True,
+            }
+        ],
+        networks=[{"uuid": network_id}],
+        security_groups=[{"name": security_group_name}],
+        key_name=key_name,
+    )
+    if host_fqdn:
+        server_kwargs["availability_zone"] = f"nova:{host_fqdn}"
+
+    server = conn.compute.create_server(**server_kwargs)
+    if wait:
+        server = wait_for_server(conn, server)
+    return server
+
+
+def delete_server(conn: connection.Connection, server_id: str | None) -> None:
+    """Удаляет сервер и ждёт завершения операции."""
+
+    if not server_id:
+        return
+    with suppress(os_exc.ResourceNotFound):
+        server = conn.compute.get_server(server_id)
+        if not server:
+            return
+        conn.compute.delete_server(server, ignore_missing=True)
+        conn.compute.wait_for_delete(server)
+
+
+def detach_volume(
+    conn: connection.Connection,
+    *,
+    server_id: str,
+    volume_id: str,
+    wait: bool = True,
+) -> None:
+    """Отсоединяет том от сервера."""
+
+    server = conn.compute.get_server(server_id)
+    if not server:
+        return
+    attachments = getattr(server, "attachments", []) or []
+    attachment_id = None
+    for attachment in attachments:
+        if attachment.get("volume_id") == volume_id:
+            attachment_id = attachment.get("id")
+            break
+    if attachment_id:
+        conn.compute.delete_volume_attachment(attachment_id, server)
+    else:
+        # Fallback: попросим Nova отсоединить по ID тома.
+        conn.compute.detach_volume(server, volume_id)
+    if wait:
+        volume = conn.block_storage.get_volume(volume_id)
+        if volume is not None:
+            wait_for_volume(conn, volume)
+
+
+__all__ = [
+    "COMPUTE_API_VERSION",
+    "DEFAULT_HOST_DOMAIN",
+    "IMAGE_ID",
+    "KEY_NAME",
+    "NETWORK_NAME",
+    "SECURITY_GROUP_ID",
+    "SERVER_NAME_PREFIX",
+    "ResolvedResources",
+    "build_host_fqdn",
+    "connect",
+    "create_server_from_volume",
+    "create_volume",
+    "delete_server",
+    "delete_volume",
+    "detach_volume",
+    "ensure_positive_size",
+    "resolve_base_resources",
+    "wait_for_server",
+    "wait_for_volume",
+]


### PR DESCRIPTION
## Summary
- factor shared configuration and helper utilities into `openstack_utils.py`
- update `create_vm.py` to rely on the reusable helper module
- add `check_services.py` end-to-end service verification script and document both tools in the README

## Testing
- python3 -m compileall create_vm.py check_services.py openstack_utils.py

------
https://chatgpt.com/codex/tasks/task_b_68e1691fbb248332b764c66eb92dd34e